### PR TITLE
Playlist detail improvement

### DIFF
--- a/playlist-app/src/components/PlaylistDetail.vue
+++ b/playlist-app/src/components/PlaylistDetail.vue
@@ -235,20 +235,13 @@ onBeforeUnmount(() => {
   display: grid;
   grid-template-columns: 60% 20% 20%;
   align-items: center;
-  /* gap: 1rem; */
   flex-grow: 2;
-  /* justify-content: space-around; */
   padding: 0.5rem;
 }
 .song-title {
   font-weight: bold;
   font-size: 0.875rem;
   color: #333;
-}
-.request-table-header {
-  font-weight: bold;
-  font-size: 0.875rem;
-  color: #666;
 }
 
 .song-info {
@@ -358,7 +351,12 @@ onBeforeUnmount(() => {
   .close-date span {
   color: #6c63ff;
   font-weight: bold;
-}
+  }
+  .request-table-header {
+  font-weight: bold;
+  font-size: 0.875rem;
+  color: #666;
+  }
 }
 
 
@@ -367,6 +365,9 @@ onBeforeUnmount(() => {
   .playlist-cover-id {
     width: 285px;
     height: 288px;
+  }
+  .request-table-header {
+    display: none;
   }
 
   .desktop-artist {
@@ -387,15 +388,8 @@ onBeforeUnmount(() => {
   .playlist-detail-container {
     flex-direction: column;
   }
-  .request-table-header,
-  .request-row {
-    display: flex;
-    flex-direction: column;
-    align-items: flex-start;
-  }
   .request-row{
-        border-top: 1px solid #ddd;
-
+    border-top: 1px solid #ddd;
   }
   .description {
     display: none;

--- a/playlist-app/src/components/PlaylistDetail.vue
+++ b/playlist-app/src/components/PlaylistDetail.vue
@@ -75,7 +75,7 @@
               <span class="song-details-ui" >{{ song.requested_by }}</span>
               <div class="action-menu-wrapper" :ref="el => menuRefs[song.id] = el">
                 <img
-                  src="/icons/inactive-select-buttons.svg"
+                  :src="openMenuId === song.id ? '/icons/active-select-buttons.svg' : '/icons/inactive-select-buttons.svg'"
                   class="action-icon"
                   @click="toggleMenu(song.id)"
                 />

--- a/playlist-app/src/components/PlaylistDetail.vue
+++ b/playlist-app/src/components/PlaylistDetail.vue
@@ -258,12 +258,6 @@ onBeforeUnmount(() => {
 .artist {
   font-size: 0.875rem;
 }
-.added-by {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  font-size: 0.875rem;
-}
 
 .song-details-ui {
   color: #7C7C7C;
@@ -281,8 +275,8 @@ onBeforeUnmount(() => {
 }
 .popup-menu {
   position: absolute;
-  top: 100%;
-  /* right: 0; */
+  /* top: 100%; */
+  right: 0;
   background: white;
   border: 1px solid #ccc;
   border-radius: 6px;
@@ -292,7 +286,7 @@ onBeforeUnmount(() => {
   flex-direction: column;
   gap: 0.25rem;
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
-  width: 7rem;
+  width: 9.5rem;
 }
 .popup-menu a,
 .popup-menu button {
@@ -301,11 +295,14 @@ onBeforeUnmount(() => {
   background: none;
   text-align: left;
   cursor: pointer;
+  /* padding-top: .5rem; */
+  /* border-top: 1px solid black; */
+
 }
 
 .popup-menu a:hover, .popup-menu button:hover {
   color: #6c63ff;
-  background-color: #f3f3f3;
+  font-weight: bold;
 }
 
 .song-text {
@@ -324,6 +321,13 @@ onBeforeUnmount(() => {
   .playlist-detail-container {
     flex-direction: row;
     align-items: flex-start;
+  }
+
+  .added-by {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    font-size: 0.875rem;
   }
 
   .request-row {
@@ -371,6 +375,33 @@ onBeforeUnmount(() => {
     width: 285px;
     height: 288px;
   }
+
+  .added-by {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    font-size: 0.875rem;
+    width: 100%;
+    position: relative;
+    padding-right: 5rem;
+  }
+
+
+  .added-by span {
+    flex-shrink: 0;
+  }
+
+  .action-menu-wrapper {
+    position: absolute;
+    right: 0.5rem; /* or 1rem if you want more space */
+    top: 50%;
+    transform: translateY(-50%);
+    display: flex;
+    align-items: center;
+  }
+
+
+
   .request-table-header {
     display: none;
   }

--- a/playlist-app/src/components/PlaylistDetail.vue
+++ b/playlist-app/src/components/PlaylistDetail.vue
@@ -63,12 +63,9 @@
               <img :src="song.album_cover_url" class="thumb" alt="Album cover" />
               <div class="song-text">
                 <small class="truncate song-title">{{ song.title }}</small>
-                <small class="truncate"><i>{{ song.album_name }}</i></small>
+                <small class="truncate artist"><i>{{ song.artist }}</i></small>
               </div>
             </div>
-
-            <!-- Artist -->
-            <span class="artist">{{ song.artist }}</span>
 
             <!-- Added By + Menu -->
             <div class="added-by">
@@ -233,12 +230,6 @@ onMounted(async () => {
   font-size: 0.875rem;
   color: #666;
 }
-.request-row {
-  background-color: #ffffff;
-}
-.request-row.alt-row {
-  background-color: #f3f3f3;
-}
 
 .song-info {
   display: flex;
@@ -317,6 +308,13 @@ onMounted(async () => {
     align-items: flex-start;
   }
 
+  .request-row {
+  background-color: #ffffff;
+}
+.request-row.alt-row {
+  background-color: #f3f3f3;
+}
+
   .main-column {
     flex: 0 0 40%;
     max-width: 40%;
@@ -362,6 +360,10 @@ onMounted(async () => {
     display: flex;
     flex-direction: column;
     align-items: flex-start;
+  }
+  .request-row{
+        border-top: 1px solid #ddd;
+
   }
   .desktop-title-group {
     display: none;

--- a/playlist-app/src/components/PlaylistDetail.vue
+++ b/playlist-app/src/components/PlaylistDetail.vue
@@ -64,15 +64,15 @@
               <img :src="song.album_cover_url" class="thumb" alt="Album cover" />
               <div class="song-text">
                 <small class="truncate song-title">{{ song.title }}</small>
-                <small class="truncate artist"><i>{{ song.artist }}</i></small>
+                <small class="truncate artist song-details-ui "><i>{{ song.artist }}</i></small>
               </div>
             </div>
              <!-- Artist -->
-            <span class="desktop-artist">{{ song.artist }}</span>
+            <span class="desktop-artist song-details-ui ">{{ song.artist }}</span>
 
             <!-- Added By + Menu -->
             <div class="added-by">
-              <span>{{ song.requested_by }}</span>
+              <span class="song-details-ui" >{{ song.requested_by }}</span>
               <div class="action-menu-wrapper" :ref="el => menuRefs[song.id] = el">
                 <img
                   src="/icons/inactive-select-buttons.svg"
@@ -265,6 +265,11 @@ onBeforeUnmount(() => {
   font-size: 0.875rem;
 }
 
+.song-details-ui {
+  color: #7C7C7C;
+  font-weight: 500;
+  font-size: .75rem;
+}
 .action-menu-wrapper {
   position: relative;
 }
@@ -373,6 +378,7 @@ onBeforeUnmount(() => {
   .desktop-artist {
     display: none;
   }
+
 
   .main-column {
   display: flex;

--- a/playlist-app/src/components/PlaylistDetail.vue
+++ b/playlist-app/src/components/PlaylistDetail.vue
@@ -30,6 +30,7 @@
           </p>
           <h1 class="playlist-title mobile-title">{{ playlist.title }}</h1>
         </div>
+        <p class="description"><span>From the DJ:</span> {{ playlist.description }}</p>
         <SongRequestForm
           :playlistId="playlist.id"
           :playlistDescription="playlist.description"
@@ -66,6 +67,8 @@
                 <small class="truncate artist"><i>{{ song.artist }}</i></small>
               </div>
             </div>
+             <!-- Artist -->
+            <span class="desktop artist">{{ song.artist }}</span>
 
             <!-- Added By + Menu -->
             <div class="added-by">
@@ -172,10 +175,6 @@ onMounted(async () => {
   font-weight: bold;
 }
 
-/* .main-column {
-  flex: 1;
-} */
-
 .right-column {
   flex: 2;
   width: 100%;
@@ -186,16 +185,6 @@ onMounted(async () => {
   width: 510px;
   height: 271px;
   border-radius: 7px;
-}
-
-.description {
-  font-size: 0.875rem;
-  margin-bottom: 1rem;
-  text-align: left;
-}
-.description span {
-  color: #6c63ff;
-  font-weight: bold;
 }
 
 .close-date {
@@ -309,12 +298,20 @@ onMounted(async () => {
   }
 
   .request-row {
-  background-color: #ffffff;
-}
-.request-row.alt-row {
-  background-color: #f3f3f3;
-}
-
+    background-color: #ffffff;
+  }
+  .request-row.alt-row {
+    background-color: #f3f3f3;
+  }
+  .description {
+  font-size: 0.875rem;
+  margin-bottom: 1rem;
+  text-align: left;
+  }
+  .description span {
+    color: #6c63ff;
+    font-weight: bold;
+  }
   .main-column {
     flex: 0 0 40%;
     max-width: 40%;
@@ -341,6 +338,10 @@ onMounted(async () => {
     height: 288px;
   }
 
+  .desktop, .artist {
+    display: none;
+  }
+
   .main-column {
   display: flex;
   flex-direction: column;
@@ -364,6 +365,9 @@ onMounted(async () => {
   .request-row{
         border-top: 1px solid #ddd;
 
+  }
+  .description {
+    display: none;
   }
   .desktop-title-group {
     display: none;

--- a/playlist-app/src/components/PlaylistDetail.vue
+++ b/playlist-app/src/components/PlaylistDetail.vue
@@ -68,7 +68,7 @@
               </div>
             </div>
              <!-- Artist -->
-            <span class="desktop artist">{{ song.artist }}</span>
+            <span class="desktop-artist">{{ song.artist }}</span>
 
             <!-- Added By + Menu -->
             <div class="added-by">
@@ -338,7 +338,7 @@ onMounted(async () => {
     height: 288px;
   }
 
-  .desktop, .artist {
+  .desktop-artist {
     display: none;
   }
 

--- a/playlist-app/src/components/PlaylistDetail.vue
+++ b/playlist-app/src/components/PlaylistDetail.vue
@@ -30,14 +30,14 @@
           </p>
           <h1 class="playlist-title mobile-title">{{ playlist.title }}</h1>
         </div>
-        <p class="description"><span>From the DJ:</span> {{ playlist.description }}</p>
-
         <SongRequestForm
           :playlistId="playlist.id"
+          :playlistDescription="playlist.description"
           @request-submitted="fetchSongs"
           @request-started="isSubmitting = true"
           @request-ended="isSubmitting = false"
         />
+
 
       </div>
 
@@ -407,6 +407,8 @@ onMounted(async () => {
   }
   .mobile-title {
     font-size: 1.5rem;
+    font-weight: 500;
+    margin: 1rem;
   }
 }
 

--- a/playlist-app/src/components/SongRequestForm.vue
+++ b/playlist-app/src/components/SongRequestForm.vue
@@ -32,6 +32,10 @@
       </div>
     </div>
 
+    <p class="dj-note">
+      <span>From the DJ:</span> {{ playlistDescription }}
+    </p>
+
     <!-- Search Results -->
     <div v-if="searchResults.length > 0" class="search-results">
       <div
@@ -58,7 +62,6 @@ import { ref } from 'vue'
 import { supabase } from '@/lib/supabase'
 import { getSpotifyAccessToken } from '@/lib/spotify'
 
-const props = defineProps<{ playlistId: string }>()
 const emit = defineEmits(['request-submitted', 'request-started', 'request-ended'])
 
 const requestedBy = ref('')
@@ -67,6 +70,10 @@ const searchQuery = ref('')
 const searchResults = ref<any[]>([])
 
 
+const props = defineProps<{
+  playlistId: string
+  playlistDescription: string
+}>()
 
 const handleSearch = async () => {
   if (searchQuery.value.trim().length < 2) {
@@ -190,11 +197,25 @@ const submitRequest = async (track: any) => {
   background-color: #fff;
   font-weight: 500;
   font-size: 14px;
-  padding-left: 15px; /* 👈 creates space for icon */
+  padding-left: 30px; /* 👈 creates space for icon */
   border: 1px solid #ccc;
   border-radius: 6px;
   color: #333;
 }
+
+.dj-note {
+  font-size: 0.85rem;
+  margin-top: 0.75rem;
+  text-align: left;
+  color: #888;
+  padding: 0 0.5rem;
+}
+
+.dj-note span {
+  font-weight: bold;
+  color: #6c63ff;
+}
+
 
 
 .search-bar-wrapper::before {

--- a/playlist-app/src/components/SongRequestForm.vue
+++ b/playlist-app/src/components/SongRequestForm.vue
@@ -27,7 +27,7 @@
           src="/icons/delete-text.svg"
           class="delete-text-icon"
           alt="Clear"
-          @click="searchQuery = ''"
+          @click="clearSearch"
         />
       </div>
     </div>
@@ -96,6 +96,10 @@ const handleSearch = async () => {
   searchResults.value = data.tracks?.items || []
 }
 
+const clearSearch = () => {
+  searchQuery.value = ''
+  searchResults.value = []
+}
 
 const getAppleMusicUrl = async (spotifyUrl: string): Promise<string | null> => {
   try {

--- a/playlist-app/src/components/SongRequestForm.vue
+++ b/playlist-app/src/components/SongRequestForm.vue
@@ -142,7 +142,6 @@ const submitRequest = async (track: any) => {
     alert('Failed to submit request: ' + error.message)
   } else {
     emit('request-submitted')
-    requestedBy.value = ''
     searchQuery.value = ''
     searchResults.value = []
   }

--- a/playlist-app/src/components/SongRequestForm.vue
+++ b/playlist-app/src/components/SongRequestForm.vue
@@ -19,7 +19,7 @@
       <div class="search-bar-wrapper">
         <input
           v-model="searchQuery"
-          placeholder="　 Search"
+          placeholder="Search"
           @input="handleSearch"
         />
         <img
@@ -151,17 +151,7 @@ const submitRequest = async (track: any) => {
 </script>
 
 <style scoped>
-/* .search-input {
-  display: flex;
-  gap: 0.5rem;
-  align-items: flex-start;
-  flex-wrap: wrap;
-}
 
-.search-input input {
-  flex: 1;
-  padding: 0.4rem;
-} */
 
 .search-input {
   display: flex;
@@ -174,9 +164,8 @@ const submitRequest = async (track: any) => {
 
 
 .search-input input {
-  width: 173px;
+  width: 1.5fr;
   height: 28px;
-  /* padding: 0 0.5rem; */
   font-size: 14px;
   border: 1px solid #ccc;
   border-radius: 6px;
@@ -188,11 +177,11 @@ const submitRequest = async (track: any) => {
 
 .search-bar-wrapper {
   position: relative;
-  flex: 1;
+  /* flex: 1; */
 }
 
 .search-bar-wrapper input {
-  width: 173px;
+  width: 1.5fr;
   height: 28px;
   background-color: #fff;
   font-weight: 500;
@@ -202,21 +191,6 @@ const submitRequest = async (track: any) => {
   border-radius: 6px;
   color: #333;
 }
-
-.dj-note {
-  font-size: 0.85rem;
-  margin-top: 0.75rem;
-  text-align: left;
-  color: #888;
-  padding: 0 0.5rem;
-}
-
-.dj-note span {
-  font-weight: bold;
-  color: #6c63ff;
-}
-
-
 
 .search-bar-wrapper::before {
   content: '';
@@ -292,6 +266,27 @@ const submitRequest = async (track: any) => {
   width: 14px;
   height: 14px;
 }
+/* Desktop */
+@media (min-width: 769px) {
+  .dj-note {
+    display: none;
+  }
+}
 
+/* Mobile */
+@media (max-width: 768px) {
+  .dj-note {
+  font-size: 0.85rem;
+  margin-top: 0.75rem;
+  text-align: left;
+  color: #888;
+  padding: 0 0.5rem;
+}
+
+.dj-note span {
+  font-weight: bold;
+  color: #6c63ff;
+}
+}
 
 </style>

--- a/playlist-app/src/components/SongRequestForm.vue
+++ b/playlist-app/src/components/SongRequestForm.vue
@@ -46,7 +46,7 @@
         <img :src="track.album.images[2]?.url" class="search-result-art" alt="Album Art" />
         <div class="search-result-text">
           <p>{{ track.name }}</p>
-          <small>{{ track.artists.map(a => a.name).join(', ') }}</small>
+          <small class="song-details-ui">{{ track.artists.map(a => a.name).join(', ') }}</small>
         </div>
         <button @click="submitRequest(track)" class="add-song-btn">
           <img src="/icons/add-song-button.svg" alt="Add Song" />
@@ -172,6 +172,12 @@ const submitRequest = async (track: any) => {
   color: #9a9a9a;
   padding-left: 15px; /* 👈 creates space for icon */
 
+}
+
+.song-details-ui {
+  color: #7C7C7C;
+  font-weight: 500;
+  font-size: .75rem;
 }
 
 .search-bar-wrapper {


### PR DESCRIPTION
- [x] move from the dj inside song request form
- [x] remove table header from mobile view
- [ ] fix odd gap between from the dj and song list
- [x] when you press x, all search queries should vanish
- [x] DJ req remain on top with desktop ver
- [x] clicking away from the pop up modal, closes it
- [ ] figure out how to display "added by"
- [x] click the menu buttons they turn purple
- [x] remove grey/white background on already added soun tracks and add grey line
- [x] you shouldnt need to reenter your name everytime you add a new song
- [x] overlapping of magnifying glass and text

<img width="1470" alt="Screenshot 2025-06-18 at 10 52 58" src="https://github.com/user-attachments/assets/f7b0435f-cba6-45b3-94d7-50072e49ea80" />
